### PR TITLE
Add missing colors dependency to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "stylelint": "^7.7.1"
   },
   "dependencies": {
+    "colors": "^1.1.2",
     "functional-javascript-workshop": "^1.0.6",
     "javascripting": "^2.6.1"
   }


### PR DESCRIPTION
`npm test` fails for students who hadn't installed `colors` separately.